### PR TITLE
Async CacheRepository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -243,3 +243,10 @@ ModelManifest.xml
 
 # FAKE - F# Make
 .fake/
+
+# VS Code
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json

--- a/Framework/CQRSlite.Tests/Cache/When_evicting_cache_entry.cs
+++ b/Framework/CQRSlite.Tests/Cache/When_evicting_cache_entry.cs
@@ -14,7 +14,7 @@ namespace CQRSlite.Tests.Cache
         private CacheRepository _rep;
         private TestAggregate _aggregate;
         private ICache _cache;
-        private ConcurrentDictionary<Guid, ManualResetEvent> _locks;
+        private ConcurrentDictionary<Guid, SemaphoreSlim> _locks;
 
         public When_evicting_cache_entry()
         {
@@ -22,17 +22,14 @@ namespace CQRSlite.Tests.Cache
             _rep = new CacheRepository(new TestRepository(), new TestEventStore(), _cache);
             _aggregate = _rep.Get<TestAggregate>(Guid.NewGuid()).Result;
             var field = _rep.GetType().GetField("_locks", BindingFlags.Static | BindingFlags.NonPublic);
-            _locks = (ConcurrentDictionary<Guid, ManualResetEvent>)field.GetValue(_rep);
-            _locks.TryGetValue(_aggregate.Id, out var resetEvent);
+            _locks = (ConcurrentDictionary<Guid, SemaphoreSlim>)field.GetValue(_rep);
             _cache.Remove(_aggregate.Id);
-            resetEvent.WaitOne(500);
         }
 
         [Fact]
         public void Should_remove_lock()
         {
-            _locks.TryGetValue(_aggregate.Id, out var val);
-            Assert.Null(val);
+            Assert.False(_locks.TryGetValue(_aggregate.Id, out var val));
         }
 
         [Fact]

--- a/Framework/CQRSlite.Tests/Cache/When_evicting_cache_entry.cs
+++ b/Framework/CQRSlite.Tests/Cache/When_evicting_cache_entry.cs
@@ -18,7 +18,7 @@ namespace CQRSlite.Tests.Cache
 
         public When_evicting_cache_entry()
         {
-            _cache = new MemoryCache();
+            _cache = new TestMemoryCache();
             _rep = new CacheRepository(new TestRepository(), new TestEventStore(), _cache);
             _aggregate = _rep.Get<TestAggregate>(Guid.NewGuid()).Result;
             var field = _rep.GetType().GetField("_locks", BindingFlags.Static | BindingFlags.NonPublic);

--- a/Framework/CQRSlite.Tests/Cache/When_saving_same_aggregate_in_parallel.cs
+++ b/Framework/CQRSlite.Tests/Cache/When_saving_same_aggregate_in_parallel.cs
@@ -26,7 +26,7 @@ namespace CQRSlite.Tests.Cache
             _aggregate = new TestAggregate(Guid.NewGuid());
             _rep1.Save(_aggregate).Wait();
 
-            var t1 = new Task(async () =>
+            var t1 = Task.Run(async () =>
             {
                 for (var i = 0; i < 100; i++)
                 {
@@ -36,7 +36,7 @@ namespace CQRSlite.Tests.Cache
                 }
             });
 
-            var t2 = new Task(async () =>
+            var t2 = Task.Run(async () =>
             {
                 for (var i = 0; i < 100; i++)
                 {
@@ -45,7 +45,7 @@ namespace CQRSlite.Tests.Cache
                     await _rep2.Save(aggregate);
                 }
             });
-            var t3 = new Task(async () =>
+            var t3 = Task.Run(async () =>
             {
                 for (var i = 0; i < 100; i++)
                 {
@@ -54,9 +54,6 @@ namespace CQRSlite.Tests.Cache
                     await _rep2.Save(aggregate);
                 }
             });
-            t1.Start();
-            t2.Start();
-            t3.Start();
 
             Task.WaitAll(t1, t2, t3);
         }

--- a/Framework/CQRSlite.Tests/Substitutes/TestMemoryCache.cs
+++ b/Framework/CQRSlite.Tests/Substitutes/TestMemoryCache.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+using CQRSlite.Cache;
+using CQRSlite.Domain;
+
+namespace CQRSlite.Tests.Substitutes
+{
+    public class TestMemoryCache : ICache
+    {
+        private readonly Dictionary<Guid, AggregateRoot> _cache = new Dictionary<Guid, AggregateRoot>();
+
+        private Action<Guid> _evictionCallback;
+
+        public AggregateRoot Get(Guid id)
+        {
+            return _cache[id];
+        }
+
+        public bool IsTracked(Guid id)
+        {
+            return _cache.ContainsKey(id);
+        }
+
+        public void RegisterEvictionCallback(Action<Guid> action)
+        {
+            _evictionCallback = action;
+        }
+
+        public void Remove(Guid id)
+        {
+            _cache.Remove(id);
+            _evictionCallback(id);
+        }
+
+        public void Set(Guid id, AggregateRoot aggregate)
+        {
+            _cache[id] = aggregate;
+        }
+    }
+}

--- a/Framework/CQRSlite/Cache/CacheRepository.cs
+++ b/Framework/CQRSlite/Cache/CacheRepository.cs
@@ -13,7 +13,10 @@ namespace CQRSlite.Cache
         private readonly IRepository _repository;
         private readonly IEventStore _eventStore;
         private readonly ICache _cache;
-        private static readonly ConcurrentDictionary<Guid, ManualResetEvent> _locks = new ConcurrentDictionary<Guid, ManualResetEvent>();
+        private static readonly ConcurrentDictionary<Guid, SemaphoreSlim> _locks =
+            new ConcurrentDictionary<Guid, SemaphoreSlim>();
+
+        private static SemaphoreSlim CreateLock(Guid _) => new SemaphoreSlim(1, 1);
 
         public CacheRepository(IRepository repository, IEventStore eventStore, ICache cache)
         {
@@ -21,71 +24,66 @@ namespace CQRSlite.Cache
             _eventStore = eventStore ?? throw new ArgumentNullException(nameof(eventStore));
             _cache = cache ?? throw new ArgumentNullException(nameof(cache));
 
-            _cache.RegisterEvictionCallback(key =>
-                     {
-                         _locks.TryRemove(key, out var o);
-                         o?.Set();
-                     });
-
+            _cache.RegisterEvictionCallback(key => _locks.TryRemove(key, out var o));
         }
 
-        public Task Save<T>(T aggregate, int? expectedVersion = null) where T : AggregateRoot
+        public async Task Save<T>(T aggregate, int? expectedVersion = null) where T : AggregateRoot
         {
+            var @lock = _locks.GetOrAdd(aggregate.Id, CreateLock);
+            await @lock.WaitAsync();
             try
             {
-                lock (_locks.GetOrAdd(aggregate.Id, _ => new ManualResetEvent(false)))
+                if (aggregate.Id != Guid.Empty && !_cache.IsTracked(aggregate.Id))
                 {
-                    if (aggregate.Id != Guid.Empty && !_cache.IsTracked(aggregate.Id))
-                    {
-                        _cache.Set(aggregate.Id, aggregate);
-                    }
-                    return _repository.Save(aggregate, expectedVersion);
+                    _cache.Set(aggregate.Id, aggregate);
                 }
+                await _repository.Save(aggregate, expectedVersion);
             }
             catch (Exception)
             {
-                lock (_locks.GetOrAdd(aggregate.Id, _ => new ManualResetEvent(false)))
-                {
-                    _cache.Remove(aggregate.Id);
-                }
+                _cache.Remove(aggregate.Id);
                 throw;
+            }
+            finally
+            {
+                @lock.Release();
             }
         }
 
-        public Task<T> Get<T>(Guid aggregateId) where T : AggregateRoot
+        public async Task<T> Get<T>(Guid aggregateId) where T : AggregateRoot
         {
+            var @lock = _locks.GetOrAdd(aggregateId, CreateLock);
+            await @lock.WaitAsync();
             try
             {
-                lock (_locks.GetOrAdd(aggregateId, _ => new ManualResetEvent(false)))
+                T aggregate;
+                if (_cache.IsTracked(aggregateId))
                 {
-                    T aggregate;
-                    if (_cache.IsTracked(aggregateId))
+                    aggregate = (T)_cache.Get(aggregateId);
+                    var events = await _eventStore.Get<T>(aggregateId, aggregate.Version);
+                    if (events.Any() && events.First().Version != aggregate.Version + 1)
                     {
-                        aggregate = (T)_cache.Get(aggregateId);
-                        var events = _eventStore.Get<T>(aggregateId, aggregate.Version).Result;
-                        if (events.Any() && events.First().Version != aggregate.Version + 1)
-                        {
-                            _cache.Remove(aggregateId);
-                        }
-                        else
-                        {
-                            aggregate.LoadFromHistory(events);
-                            return Task.FromResult(aggregate);
-                        }
+                        _cache.Remove(aggregateId);
                     }
-
-                    aggregate = _repository.Get<T>(aggregateId).Result;
-                    _cache.Set(aggregateId, aggregate);
-                    return Task.FromResult(aggregate);
+                    else
+                    {
+                        aggregate.LoadFromHistory(events);
+                        return aggregate;
+                    }
                 }
+
+                aggregate = await _repository.Get<T>(aggregateId);
+                _cache.Set(aggregateId, aggregate);
+                return aggregate;
             }
             catch (Exception)
             {
-                lock (_locks.GetOrAdd(aggregateId, _ => new ManualResetEvent(false)))
-                {
-                    _cache.Remove(aggregateId);
-                }
+                _cache.Remove(aggregateId);
                 throw;
+            }
+            finally
+            {
+                @lock.Release();
             }
         }
     }


### PR DESCRIPTION
Remove synchronous code from CacheRepository

    - Use SemaphoreSlim instead of monitor
    - Use async/await
    - Fix async tasks not being awaited in test cases, the use of `new Task`
      as opposed to `Task.Run` caused odd things to happen with the awaited
      semaphore (the task to acquire the semaphore was not awaited)
    - ManualResetEvent no longer required in test. If there turns out to be
      a race condition, then I think we should bring in a mocking framework
      and mock the ICache