### PR TITLE
Remove generic parameter from IEventStore

### DIFF
--- a/Framework/CQRSlite.Tests.Extensions/TestHelpers/Specification.cs
+++ b/Framework/CQRSlite.Tests.Extensions/TestHelpers/Specification.cs
@@ -107,14 +107,14 @@ namespace CQRSlite.Tests.Extensions.TestHelpers
 
         public List<IEvent> Events { get; set; }
 
-        public Task Save<T>(IEnumerable<IEvent> events)
+        public Task Save(IEnumerable<IEvent> events)
         {
             Events.AddRange(events);
             return Task.WhenAll(events.Select(evt =>_publisher.Publish(evt)));
                 
         }
 
-        public Task<IEnumerable<IEvent>> Get<T>(Guid aggregateId, int fromVersion)
+        public Task<IEnumerable<IEvent>> Get(Guid aggregateId, int fromVersion)
         {
             var events = Events.Where(x => x.Id == aggregateId && x.Version > fromVersion);
             return Task.FromResult(events);

--- a/Framework/CQRSlite.Tests/Substitutes/TestEventStore.cs
+++ b/Framework/CQRSlite.Tests/Substitutes/TestEventStore.cs
@@ -16,7 +16,7 @@ namespace CQRSlite.Tests.Substitutes
             SavedEvents = new List<IEvent>();
         }
 
-        public Task<IEnumerable<IEvent>> Get<T>(Guid aggregateId, int version)
+        public Task<IEnumerable<IEvent>> Get(Guid aggregateId, int version)
         {
             if (aggregateId == _emptyGuid || aggregateId == Guid.Empty)
             {
@@ -31,7 +31,7 @@ namespace CQRSlite.Tests.Substitutes
             }.Where(x => x.Version > version));
         }
 
-        public Task Save<T>(IEnumerable<IEvent> events)
+        public Task Save(IEnumerable<IEvent> events)
         {
             SavedEvents.AddRange(events);
             return Task.CompletedTask;

--- a/Framework/CQRSlite.Tests/Substitutes/TestEventStoreWithBugs.cs
+++ b/Framework/CQRSlite.Tests/Substitutes/TestEventStoreWithBugs.cs
@@ -7,12 +7,12 @@ namespace CQRSlite.Tests.Substitutes
 {
     public class TestEventStoreWithBugs : IEventStore
     {
-        public Task Save<T>(IEnumerable<IEvent> events)
+        public Task Save(IEnumerable<IEvent> events)
         {
             return Task.CompletedTask;
         }
 
-        public Task<IEnumerable<IEvent>> Get<T>(Guid aggregateId, int version)
+        public Task<IEnumerable<IEvent>> Get(Guid aggregateId, int version)
         {
             if (aggregateId == Guid.Empty)
             {

--- a/Framework/CQRSlite.Tests/Substitutes/TestInMemoryEventStore.cs
+++ b/Framework/CQRSlite.Tests/Substitutes/TestInMemoryEventStore.cs
@@ -10,7 +10,7 @@ namespace CQRSlite.Tests.Substitutes
     {
         public readonly List<IEvent> Events = new List<IEvent>();
 
-        public Task Save<T>(IEnumerable<IEvent> events)
+        public Task Save(IEnumerable<IEvent> events)
         {
             lock (Events)
             {
@@ -19,7 +19,7 @@ namespace CQRSlite.Tests.Substitutes
             return Task.CompletedTask;
         }
 
-        public Task<IEnumerable<IEvent>> Get<T>(Guid aggregateId, int fromVersion)
+        public Task<IEnumerable<IEvent>> Get(Guid aggregateId, int fromVersion)
         {
             lock(Events)
             {

--- a/Framework/CQRSlite/Cache/CacheRepository.cs
+++ b/Framework/CQRSlite/Cache/CacheRepository.cs
@@ -62,7 +62,7 @@ namespace CQRSlite.Cache
                     if (_cache.IsTracked(aggregateId))
                     {
                         aggregate = (T)_cache.Get(aggregateId);
-                        var events = _eventStore.Get<T>(aggregateId, aggregate.Version).Result;
+                        var events = _eventStore.Get(aggregateId, aggregate.Version).Result;
                         if (events.Any() && events.First().Version != aggregate.Version + 1)
                         {
                             _cache.Remove(aggregateId);

--- a/Framework/CQRSlite/Domain/Repository.cs
+++ b/Framework/CQRSlite/Domain/Repository.cs
@@ -26,13 +26,13 @@ namespace CQRSlite.Domain
 
         public async Task Save<T>(T aggregate, int? expectedVersion = null) where T : AggregateRoot
         {
-            if (expectedVersion != null && (await _eventStore.Get<T>(aggregate.Id, expectedVersion.Value)).Any())
+            if (expectedVersion != null && (await _eventStore.Get(aggregate.Id, expectedVersion.Value)).Any())
             {
                 throw new ConcurrencyException(aggregate.Id);
             }
 
             var changes = aggregate.FlushUncommitedChanges();
-            await _eventStore.Save<T>(changes);
+            await _eventStore.Save(changes);
 
             if (_publisher != null)
             {
@@ -50,7 +50,7 @@ namespace CQRSlite.Domain
 
         private async Task<T> LoadAggregate<T>(Guid id) where T : AggregateRoot
         {
-            var events = await _eventStore.Get<T>(id, -1);
+            var events = await _eventStore.Get(id, -1);
             if (!events.Any())
             {
                 throw new AggregateNotFoundException(typeof(T), id);

--- a/Framework/CQRSlite/Events/IEventStore.cs
+++ b/Framework/CQRSlite/Events/IEventStore.cs
@@ -6,7 +6,7 @@ namespace CQRSlite.Events
 {
     public interface IEventStore
     {
-        Task Save<T>(IEnumerable<IEvent> events);
-        Task<IEnumerable<IEvent>> Get<T>(Guid aggregateId, int fromVersion);
+        Task Save(IEnumerable<IEvent> events);
+        Task<IEnumerable<IEvent>> Get(Guid aggregateId, int fromVersion);
     }
 }

--- a/Framework/CQRSlite/Snapshots/SnapshotRepository.cs
+++ b/Framework/CQRSlite/Snapshots/SnapshotRepository.cs
@@ -36,7 +36,7 @@ namespace CQRSlite.Snapshots
             {
                 return await _repository.Get<T>(aggregateId);
             }
-            var events = (await _eventStore.Get<T>(aggregateId, snapshotVersion)).Where(desc => desc.Version > snapshotVersion);
+            var events = (await _eventStore.Get(aggregateId, snapshotVersion)).Where(desc => desc.Version > snapshotVersion);
             aggregate.LoadFromHistory(events);
 
             return aggregate;

--- a/Sample/CQRSCode/WriteModel/InMemoryEventStore.cs
+++ b/Sample/CQRSCode/WriteModel/InMemoryEventStore.cs
@@ -16,7 +16,7 @@ namespace CQRSCode.WriteModel
             _publisher = publisher;
         }
 
-        public async Task Save<T>(IEnumerable<IEvent> events)
+        public async Task Save(IEnumerable<IEvent> events)
         {
             foreach (var @event in events)
             {
@@ -31,7 +31,7 @@ namespace CQRSCode.WriteModel
             }
         }
 
-        public Task<IEnumerable<IEvent>> Get<T>(Guid aggregateId, int fromVersion)
+        public Task<IEnumerable<IEvent>> Get(Guid aggregateId, int fromVersion)
         {
             _inMemoryDb.TryGetValue(aggregateId, out var events);
             return Task.FromResult(events?.Where(x => x.Version > fromVersion) ?? new List<IEvent>());


### PR DESCRIPTION
Remove the generic type parameter from event store as it is always resolves as AggregateRoot