### PR TITLE
Readonly expectedversion on ICommand

### DIFF
--- a/Framework/CQRSlite/Commands/ICommand.cs
+++ b/Framework/CQRSlite/Commands/ICommand.cs
@@ -4,6 +4,6 @@ namespace CQRSlite.Commands
 {
     public interface ICommand : IMessage
     {
-        int ExpectedVersion { get; set; }
+        int ExpectedVersion { get; }
     }
 }


### PR DESCRIPTION
Do not require a public setter on `ICommand.ExpectedVersion`. This doesn't force anyone implementing ICommand to have a public setter on ExpectedVersion, but still allows someone to have a public setter if they wish. It's a small, simple change but very helpful for anyone who prefers that ExpectedVersion not be accidentally changed after command construction.