### PR TITLE
Supporting .NET Framework 4.5.2

### DIFF
--- a/CQRSlite.nuspec
+++ b/CQRSlite.nuspec
@@ -13,6 +13,8 @@
     <dependencies>
       <group targetFramework=".NETFramework4.6.1">
       </group>
+      <group targetFramework=".NETFramework4.5.2">
+      </group>
       <group targetFramework=".NETStandard1.3">
         <dependency id="NETStandard.Library" version="1.6.1" />
         <dependency id="System.Dynamic.Runtime" version="4.3.0" />
@@ -38,5 +40,7 @@
     <file src="Framework\CQRSlite\bin\Release\netstandard1.5\CQRSlite.deps.json" target="lib\netstandard1.5\CQRSlite.deps.json" />
     <file src="Framework\CQRSlite\bin\Release\net461\CQRSlite.dll" target="lib\net461\CQRSlite.dll" />
     <file src="Framework\CQRSlite\bin\Release\net461\CQRSlite.pdb" target="lib\net461\CQRSlite.pdb" />
+    <file src="Framework\CQRSlite\bin\Release\net452\CQRSlite.dll" target="lib\net452\CQRSlite.dll" />
+    <file src="Framework\CQRSlite\bin\Release\net452\CQRSlite.pdb" target="lib\net452\CQRSlite.pdb" />
   </files>
 </package>

--- a/CQRSlite.nuspec
+++ b/CQRSlite.nuspec
@@ -11,8 +11,6 @@
     <description>A lightweight framework to help write CQRS and Eventsourcing applications in C#</description>
     <copyright>Copyright 2017</copyright>
     <dependencies>
-      <group targetFramework=".NETFramework4.6.1">
-      </group>
       <group targetFramework=".NETFramework4.5.2">
       </group>
       <group targetFramework=".NETStandard1.3">
@@ -38,8 +36,6 @@
     <file src="Framework\CQRSlite\bin\Release\netstandard1.5\CQRSlite.dll" target="lib\netstandard1.5\CQRSlite.dll" />
     <file src="Framework\CQRSlite\bin\Release\netstandard1.5\CQRSlite.pdb" target="lib\netstandard1.5\CQRSlite.pdb" />
     <file src="Framework\CQRSlite\bin\Release\netstandard1.5\CQRSlite.deps.json" target="lib\netstandard1.5\CQRSlite.deps.json" />
-    <file src="Framework\CQRSlite\bin\Release\net461\CQRSlite.dll" target="lib\net461\CQRSlite.dll" />
-    <file src="Framework\CQRSlite\bin\Release\net461\CQRSlite.pdb" target="lib\net461\CQRSlite.pdb" />
     <file src="Framework\CQRSlite\bin\Release\net452\CQRSlite.dll" target="lib\net452\CQRSlite.dll" />
     <file src="Framework\CQRSlite\bin\Release\net452\CQRSlite.pdb" target="lib\net452\CQRSlite.pdb" />
   </files>

--- a/Framework/CQRSlite/Bus/InProcessBus.cs
+++ b/Framework/CQRSlite/Bus/InProcessBus.cs
@@ -35,11 +35,8 @@ namespace CQRSlite.Bus
         public Task Publish<T>(T @event, CancellationToken cancellationToken = default(CancellationToken)) where T : class, IEvent
         {
             if (!_routes.TryGetValue(@event.GetType(), out var handlers))
-#if NET452
                 return Task.FromResult(0);
-#else
-                return Task.CompletedTask;
-#endif
+
             return Task.WhenAll(handlers.Select(handler => handler(@event, cancellationToken)));
         }
     }

--- a/Framework/CQRSlite/Bus/InProcessBus.cs
+++ b/Framework/CQRSlite/Bus/InProcessBus.cs
@@ -35,7 +35,11 @@ namespace CQRSlite.Bus
         public Task Publish<T>(T @event, CancellationToken cancellationToken = default(CancellationToken)) where T : class, IEvent
         {
             if (!_routes.TryGetValue(@event.GetType(), out var handlers))
+#if NET452
+                return new Task(() => { });
+#else
                 return Task.CompletedTask;
+#endif
             return Task.WhenAll(handlers.Select(handler => handler(@event, cancellationToken)));
         }
     }

--- a/Framework/CQRSlite/Bus/InProcessBus.cs
+++ b/Framework/CQRSlite/Bus/InProcessBus.cs
@@ -36,7 +36,7 @@ namespace CQRSlite.Bus
         {
             if (!_routes.TryGetValue(@event.GetType(), out var handlers))
 #if NET452
-                return new Task(() => { });
+                return Task.FromResult(0);
 #else
                 return Task.CompletedTask;
 #endif

--- a/Framework/CQRSlite/CQRSlite.csproj
+++ b/Framework/CQRSlite/CQRSlite.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.3;netstandard1.5;net461;net452</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;netstandard1.5;net452</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DefineConstants>TRACE;DEBUG</DefineConstants>
@@ -17,11 +17,6 @@
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="1.1.2" />
     <PackageReference Include="System.Dynamic.Runtime" Version="4.3.0" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net461' ">
-    <Reference Include="System.Runtime.Caching" />
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net452' ">
     <Reference Include="System.Runtime.Caching" />

--- a/Framework/CQRSlite/CQRSlite.csproj
+++ b/Framework/CQRSlite/CQRSlite.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.3;netstandard1.5;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;netstandard1.5;net461;net452</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DefineConstants>TRACE;DEBUG</DefineConstants>
@@ -19,6 +19,11 @@
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net461' ">
+    <Reference Include="System.Runtime.Caching" />
+    <Reference Include="System" />
+    <Reference Include="Microsoft.CSharp" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net452' ">
     <Reference Include="System.Runtime.Caching" />
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />

--- a/Framework/CQRSlite/Cache/MemoryCache.cs
+++ b/Framework/CQRSlite/Cache/MemoryCache.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using CQRSlite.Domain;
-#if NET461
+#if NET461 || NET452
 using System.Runtime.Caching;
 #else
 using Microsoft.Extensions.Caching.Memory;
@@ -10,7 +10,7 @@ namespace CQRSlite.Cache
 {
     public class MemoryCache : ICache
     {
-#if NET461
+#if NET461 || NET452
         private readonly System.Runtime.Caching.MemoryCache _cache;
         private Func<CacheItemPolicy> _policyFactory;
 #else
@@ -21,7 +21,7 @@ namespace CQRSlite.Cache
         public MemoryCache()
         {
 
-#if NET461
+#if NET461 || NET452
             _cache = System.Runtime.Caching.MemoryCache.Default;
             _policyFactory = () => new CacheItemPolicy {
                 SlidingExpiration = TimeSpan.FromMinutes(15)
@@ -38,7 +38,7 @@ namespace CQRSlite.Cache
 
         public bool IsTracked(Guid id)
         {
-#if NET461
+#if NET461 || NET452
             return _cache.Contains(id.ToString());
 #else
             return _cache.TryGetValue(id, out var o) && o != null;
@@ -47,7 +47,7 @@ namespace CQRSlite.Cache
 
         public void Set(Guid id, AggregateRoot aggregate)
         {
-#if NET461
+#if NET461 || NET452
             _cache.Add(id.ToString(), aggregate, _policyFactory.Invoke());
 #else
             _cache.Set(id, aggregate, _cacheOptions);
@@ -56,7 +56,7 @@ namespace CQRSlite.Cache
 
         public AggregateRoot Get(Guid id)
         {
-#if NET461
+#if NET461 || NET452
             return (AggregateRoot)_cache.Get(id.ToString());
 #else
             return (AggregateRoot) _cache.Get(id);
@@ -65,7 +65,7 @@ namespace CQRSlite.Cache
 
         public void Remove(Guid id)
         {
-#if NET461
+#if NET461 || NET452
             _cache.Remove(id.ToString());
 #else
             _cache.Remove(id);
@@ -74,7 +74,7 @@ namespace CQRSlite.Cache
 
         public void RegisterEvictionCallback(Action<Guid> action)
         {
-#if NET461
+#if NET461 || NET452
             _policyFactory = () => new CacheItemPolicy
             {
                 SlidingExpiration = TimeSpan.FromMinutes(15),

--- a/Framework/CQRSlite/Cache/MemoryCache.cs
+++ b/Framework/CQRSlite/Cache/MemoryCache.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using CQRSlite.Domain;
-#if NET461 || NET452
+#if NET452
 using System.Runtime.Caching;
 #else
 using Microsoft.Extensions.Caching.Memory;
@@ -10,7 +10,7 @@ namespace CQRSlite.Cache
 {
     public class MemoryCache : ICache
     {
-#if NET461 || NET452
+#if NET452
         private readonly System.Runtime.Caching.MemoryCache _cache;
         private Func<CacheItemPolicy> _policyFactory;
 #else
@@ -21,7 +21,7 @@ namespace CQRSlite.Cache
         public MemoryCache()
         {
 
-#if NET461 || NET452
+#if NET452
             _cache = System.Runtime.Caching.MemoryCache.Default;
             _policyFactory = () => new CacheItemPolicy {
                 SlidingExpiration = TimeSpan.FromMinutes(15)
@@ -38,7 +38,7 @@ namespace CQRSlite.Cache
 
         public bool IsTracked(Guid id)
         {
-#if NET461 || NET452
+#if NET452
             return _cache.Contains(id.ToString());
 #else
             return _cache.TryGetValue(id, out var o) && o != null;
@@ -47,7 +47,7 @@ namespace CQRSlite.Cache
 
         public void Set(Guid id, AggregateRoot aggregate)
         {
-#if NET461 || NET452
+#if NET452
             _cache.Add(id.ToString(), aggregate, _policyFactory.Invoke());
 #else
             _cache.Set(id, aggregate, _cacheOptions);
@@ -56,7 +56,7 @@ namespace CQRSlite.Cache
 
         public AggregateRoot Get(Guid id)
         {
-#if NET461 || NET452
+#if NET452
             return (AggregateRoot)_cache.Get(id.ToString());
 #else
             return (AggregateRoot) _cache.Get(id);
@@ -65,7 +65,7 @@ namespace CQRSlite.Cache
 
         public void Remove(Guid id)
         {
-#if NET461 || NET452
+#if NET452
             _cache.Remove(id.ToString());
 #else
             _cache.Remove(id);
@@ -74,7 +74,7 @@ namespace CQRSlite.Cache
 
         public void RegisterEvictionCallback(Action<Guid> action)
         {
-#if NET461 || NET452
+#if NET452
             _policyFactory = () => new CacheItemPolicy
             {
                 SlidingExpiration = TimeSpan.FromMinutes(15),

--- a/Framework/CQRSlite/Domain/Session.cs
+++ b/Framework/CQRSlite/Domain/Session.cs
@@ -29,7 +29,7 @@ namespace CQRSlite.Domain
                 throw new ConcurrencyException(aggregate.Id);
             }
 #if NET452
-            return new Task(() => { });
+            return Task.FromResult(0);
 #else
             return Task.CompletedTask;
 #endif

--- a/Framework/CQRSlite/Domain/Session.cs
+++ b/Framework/CQRSlite/Domain/Session.cs
@@ -28,11 +28,7 @@ namespace CQRSlite.Domain
             {
                 throw new ConcurrencyException(aggregate.Id);
             }
-#if NET452
             return Task.FromResult(0);
-#else
-            return Task.CompletedTask;
-#endif
         }
 
         public async Task<T> Get<T>(Guid id, int? expectedVersion = null, CancellationToken cancellationToken = default(CancellationToken)) where T : AggregateRoot

--- a/Framework/CQRSlite/Domain/Session.cs
+++ b/Framework/CQRSlite/Domain/Session.cs
@@ -28,7 +28,11 @@ namespace CQRSlite.Domain
             {
                 throw new ConcurrencyException(aggregate.Id);
             }
+#if NET452
+            return new Task(() => { });
+#else
             return Task.CompletedTask;
+#endif
         }
 
         public async Task<T> Get<T>(Guid id, int? expectedVersion = null, CancellationToken cancellationToken = default(CancellationToken)) where T : AggregateRoot

--- a/Framework/CQRSlite/Snapshots/SnapshotRepository.cs
+++ b/Framework/CQRSlite/Snapshots/SnapshotRepository.cs
@@ -58,7 +58,11 @@ namespace CQRSlite.Snapshots
         private Task TryMakeSnapshot(AggregateRoot aggregate)
         {
             if (!_snapshotStrategy.ShouldMakeSnapShot(aggregate))
+#if NET452
+                return new Task(() => { });
+#else
                 return Task.CompletedTask;
+#endif
 
             var snapshot = aggregate.AsDynamic().GetSnapshot();
             snapshot.Version = aggregate.Version + aggregate.GetUncommittedChanges().Length;

--- a/Framework/CQRSlite/Snapshots/SnapshotRepository.cs
+++ b/Framework/CQRSlite/Snapshots/SnapshotRepository.cs
@@ -58,11 +58,7 @@ namespace CQRSlite.Snapshots
         private Task TryMakeSnapshot(AggregateRoot aggregate)
         {
             if (!_snapshotStrategy.ShouldMakeSnapShot(aggregate))
-#if NET452
                 return Task.FromResult(0);
-#else
-                return Task.CompletedTask;
-#endif
 
             var snapshot = aggregate.AsDynamic().GetSnapshot();
             snapshot.Version = aggregate.Version + aggregate.GetUncommittedChanges().Length;

--- a/Framework/CQRSlite/Snapshots/SnapshotRepository.cs
+++ b/Framework/CQRSlite/Snapshots/SnapshotRepository.cs
@@ -59,7 +59,7 @@ namespace CQRSlite.Snapshots
         {
             if (!_snapshotStrategy.ShouldMakeSnapShot(aggregate))
 #if NET452
-                return new Task(() => { });
+                return Task.FromResult(0);
 #else
                 return Task.CompletedTask;
 #endif


### PR DESCRIPTION
Due to recommendations of our customer we could not update to .NET 4.6.x.

Please accept this small changes to support .NET 4.5.2 also.