### PR TITLE
Enable BusRegistrar to invoke nonpublic handlers.

### DIFF
--- a/Framework/CQRSlite.Tests/Bus/When_registering_handlers.cs
+++ b/Framework/CQRSlite.Tests/Bus/When_registering_handlers.cs
@@ -21,7 +21,8 @@ namespace CQRSlite.Tests.Bus
         [Fact]
         public void Should_register_all_handlers()
         {
-            Assert.Equal(4, TestHandleRegistrar.HandlerList.Count);
+            // 4 public declared handlers, one internal declared
+            Assert.Equal(5, TestHandleRegistrar.HandlerList.Count);
         }
 
         [Fact]

--- a/Framework/CQRSlite.Tests/Substitutes/TestEvents.cs
+++ b/Framework/CQRSlite.Tests/Substitutes/TestEvents.cs
@@ -14,6 +14,14 @@ namespace CQRSlite.Tests.Substitutes
         public bool LongRunning { get; set; }
     }
 
+    internal class TestAggregateDidSomethingInternal : IEvent
+    {
+        public Guid Id { get; set; }
+        public int Version { get; set; }
+        public DateTimeOffset TimeStamp { get; set; }
+        public bool LongRunning { get; set; }
+    }
+
     public class TestAggregateDidSomethingElse : IEvent
     {
         public Guid Id { get; set; }
@@ -46,6 +54,19 @@ namespace CQRSlite.Tests.Substitutes
 
         public CancellationToken Token { get; private set; }
         public int TimesRun { get; private set; }
-
     }
+
+    internal class TestAggregateDidSomethingInternalHandler : ICancellableEventHandler<TestAggregateDidSomethingInternal>
+    {
+        public Task Handle(TestAggregateDidSomethingInternal message, CancellationToken token)
+        {
+            TimesRun++;
+            Token = token;
+            return Task.FromResult(0);
+        }
+
+        public CancellationToken Token { get; private set; }
+        public int TimesRun { get; private set; }
+    }
+
 }

--- a/Framework/CQRSlite.Tests/Substitutes/TestServiceLocator.cs
+++ b/Framework/CQRSlite.Tests/Substitutes/TestServiceLocator.cs
@@ -23,18 +23,25 @@ namespace CQRSlite.Tests.Substitutes
                 Handlers.Add(handler);
                 return handler;
             }
+            if (type == typeof(TestAggregateDidSomethingInternalHandler))
+            {
+                var handler = new TestAggregateDidSomethingInternalHandler();
+                Handlers.Add(handler);
+                return handler;
+            }
             if (type == typeof(TestAggregateDoSomethingElseHandler))
             {
                 var handler = new TestAggregateDoSomethingElseHandler();
                 Handlers.Add(handler);
                 return handler;
             }
-            else
+            if (type == typeof(TestAggregateDoSomethingHandler))
             {
                 var handler = new TestAggregateDoSomethingHandler();
                 Handlers.Add(handler);
                 return handler;
             }
+            throw new ArgumentException("Type not registered");
         }
     }
 }

--- a/Framework/CQRSlite/Config/BusRegistrar.cs
+++ b/Framework/CQRSlite/Config/BusRegistrar.cs
@@ -47,7 +47,7 @@ namespace CQRSlite.Config
 
             var registerExecutorMethod = registrar
                 .GetType()
-                .GetMethods(BindingFlags.Instance | BindingFlags.Public)
+                .GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
                 .Where(mi => mi.Name == "RegisterHandler")
                 .Where(mi => mi.IsGenericMethod)
                 .Where(mi => mi.GetGenericArguments().Length == 1)


### PR DESCRIPTION
In order to use CQRSlite within a library,
iwant to be all handlers, commands and events internal.

Currently the BusRegistrar accepts only public members.

Just include BindingFlags.NonPublic to acchieve this.