### PR TITLE
netcore1.0 compatibility

### DIFF
--- a/Framework/CQRSlite/CQRSlite.csproj
+++ b/Framework/CQRSlite/CQRSlite.csproj
@@ -2,19 +2,16 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;netstandard1.5;net452</TargetFrameworks>
   </PropertyGroup>
+  <PropertyGroup>
+    <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DefineConstants>TRACE;DEBUG</DefineConstants>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.5' ">
+  <ItemGroup Condition="'$(TargetFramework)' != 'net452' ">
     <PackageReference Include="Microsoft.CSharp" Version="4.3.0" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="1.1.2" />
-    <PackageReference Include="System.Dynamic.Runtime" Version="4.3.0" />
-    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3' ">
-    <PackageReference Include="Microsoft.CSharp" Version="4.4.0" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="1.1.2" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="1.0.2" />
     <PackageReference Include="System.Dynamic.Runtime" Version="4.3.0" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0" />
   </ItemGroup>

--- a/Framework/CQRSlite/CQRSlite.csproj
+++ b/Framework/CQRSlite/CQRSlite.csproj
@@ -1,20 +1,28 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.3;netstandard1.5;net452</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;netstandard1.5;netstandard2.0;net452</TargetFrameworks>
   </PropertyGroup>
-  <PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)'=='netstandard1.3' Or '$(TargetFramework)'=='netstandard1.5'">
     <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DefineConstants>TRACE;DEBUG</DefineConstants>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'net452' ">
+  <ItemGroup Condition="'$(TargetFramework)'=='netstandard1.3' Or '$(TargetFramework)'=='netstandard1.5'">
     <PackageReference Include="Microsoft.CSharp" Version="4.3.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="1.0.2" />
     <PackageReference Include="System.Dynamic.Runtime" Version="4.3.0" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0" />
   </ItemGroup>
+  
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="Microsoft.CSharp" Version="4.4.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="1.1.2" />
+    <PackageReference Include="System.Dynamic.Runtime" Version="4.3.0" />
+    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(TargetFramework)' == 'net452' ">
     <Reference Include="System.Runtime.Caching" />
     <Reference Include="System" />


### PR DESCRIPTION
Hey hey

I've been playing around with running this on aws lambda (currently only netcore1.0 😢 ) and got stuck due to a dep on NetStandard.library v1.6.1. This change moves that version back to 1.6.0 which makes netcore1.0 happy. The penalty is a downgrade in these deps

Microsoft.CSharp v4.4 => v4.3
Microsoft.Extensions.Caching.Memory v.1.1.2 => v1.0.2

For that reason I'm guessing you might not want to merge. I'm going to push on using the fork in the meantime. I'd really appreciate any feedback if you think this might have any problems.

Keeps up the good work!