### PR TITLE
Fix to prevent RouteRegistrar from registering abstract handlers

### DIFF
--- a/Framework/CQRSlite.Tests/Substitutes/TestCommands.cs
+++ b/Framework/CQRSlite.Tests/Substitutes/TestCommands.cs
@@ -37,14 +37,19 @@ namespace CQRSlite.Tests.Substitutes
         public CancellationToken Token { get; set; }
 
     }
-	public class TestAggregateDoSomethingElseHandler : ICommandHandler<TestAggregateDoSomethingElse>
+	public class TestAggregateDoSomethingElseHandler : AbstractTestAggregateDoSomethingElseHandler
     {
-        public Task Handle(TestAggregateDoSomethingElse message)
+        public override Task Handle(TestAggregateDoSomethingElse message)
         {
             TimesRun++;
             return Task.CompletedTask;
         }
 
         public int TimesRun { get; set; }
+    }
+
+    public abstract class AbstractTestAggregateDoSomethingElseHandler : ICommandHandler<TestAggregateDoSomethingElse>
+    {
+        public abstract Task Handle(TestAggregateDoSomethingElse message);
     }
 }

--- a/Framework/CQRSlite/Routing/RouteRegistrar.cs
+++ b/Framework/CQRSlite/Routing/RouteRegistrar.cs
@@ -30,7 +30,7 @@ namespace CQRSlite.Routing
                 var executorTypes = executorsAssembly
                     .GetTypes()
                     .Select(t => new { Type = t, Interfaces = ResolveMessageHandlerInterface(t) })
-                    .Where(e => e.Interfaces != null && e.Interfaces.Any());
+                    .Where(e => e.Interfaces != null && e.Interfaces.Any() && !e.Type.GetTypeInfo().IsAbstract);
 
                 foreach (var executorType in executorTypes)
                 {


### PR DESCRIPTION
I use abstract event handlers to make some projections easier to manage, and for now I've just implemented a custom copy of the registrar with the changes in this commit. 

I added the abstract handler class; saw the test fail, and then I added the additional condition in the registrar which made the tests green again.

Maybe you have a good reason for not doing this already, if so you can just reject the PR 😄 

Thanks for this awesome project!