### PR TITLE
Remove ExpectedVersion from ICommand

### DIFF
--- a/Framework/CQRSlite/Commands/ICommand.cs
+++ b/Framework/CQRSlite/Commands/ICommand.cs
@@ -3,10 +3,9 @@
 namespace CQRSlite.Commands
 {
     /// <summary>
-    /// Defines an command with required fields.
+    /// Defines a command.
     /// </summary>
     public interface ICommand : IMessage
     {
-        int ExpectedVersion { get; }
     }
 }


### PR DESCRIPTION
ExpectedVersion is optional within the session code, so it should not be required on a command.

This change wont affect any existing users.