### PR TITLE
Maintaining tracked aggregates in Session.Commit in case of exception

### DIFF
--- a/Framework/CQRSlite/Domain/Session.cs
+++ b/Framework/CQRSlite/Domain/Session.cs
@@ -13,7 +13,7 @@ namespace CQRSlite.Domain
     {
         private readonly IRepository _repository;
         private readonly Dictionary<Guid, AggregateDescriptor> _trackedAggregates;
-        
+
         /// <summary>
         /// Initialize Session
         /// </summary>
@@ -66,15 +66,25 @@ namespace CQRSlite.Domain
 
         public async Task Commit(CancellationToken cancellationToken = default(CancellationToken))
         {
-            var tasks = new Task[_trackedAggregates.Count];
-            var i = 0;
-            foreach (var descriptor in _trackedAggregates.Values)
+            try
             {
-                tasks[i] = _repository.Save(descriptor.Aggregate, descriptor.Version, cancellationToken);
-                i++;
+                var tasks = new Task[_trackedAggregates.Count];
+                var i = 0;
+                foreach (var descriptor in _trackedAggregates.Values)
+                {
+                    tasks[i] = _repository.Save(descriptor.Aggregate, descriptor.Version, cancellationToken);
+                    i++;
+                }
+                await Task.WhenAll(tasks).ConfigureAwait(false);
             }
-            await Task.WhenAll(tasks).ConfigureAwait(false);
-            _trackedAggregates.Clear();
+            catch (System.Exception ex)
+            {
+                throw ex;
+            }
+            finally
+            {
+                _trackedAggregates.Clear();
+            }
         }
 
         private class AggregateDescriptor


### PR DESCRIPTION
In Session.Commit, the actual save to the repository (e.g. a SQL event store) or an event handler called within _repository.Save might cause an exception which will be passed on all the way to the initial call.
However, the _trackedAggregates dictionary in memory never gets cleared, therefore the _trackedAggregates and the actual state within the event store diverge.

In our case we used a SQL event store that also publishes the events.
During handling of the event an exception occured so the events never got committed to the event store. The events have however in memory been flushed using AggregateRoot.FlushUncommittedChanges, so version numbers have been increased already in memory, however the _trackedAggregates never got cleared.
As long as the application was running, this hasn't been noticed, since Session.Get always returned the aggregate from the _trackedAggregates since IsTracked() returns true with the correct version number.
Handling the next event for the same aggregate worked just fine, so the version got increased again and committed to the SQL event store.
We ended up having version gaps in the event store but no in memory.
After application restart obviously an out of sequence exception occured since the aggregate wasn't tracked yet but instead loaded from the database,

With this pull request we make sure that _trackedAggregates is maintained correctly, not causing any version gaps in case of exceptions in the event store or event handlers.