### PR TITLE
fix: Make project able to compile with VS 2017

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+ <PropertyGroup>
+   <LangVersion>7.1</LangVersion>
+ </PropertyGroup>
+</Project>


### PR DESCRIPTION
To fix the failing appveyor build we set the minimal language version to 7.1
(the default is 7.0 in VS 2017). And alternative solution would be to set
appveyor to use VS 2019.