### PR TITLE
Fixed concurrency errors in MemoryCache when using dotnetcore

### DIFF
--- a/Framework/CQRSlite.Tests/Caching/When_creating_and_using_repositories_in_parallel.cs
+++ b/Framework/CQRSlite.Tests/Caching/When_creating_and_using_repositories_in_parallel.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using CQRSlite.Caching;
+using CQRSlite.Domain;
+using CQRSlite.Tests.Substitutes;
+using Xunit;
+
+namespace CQRSlite.Tests.Caching
+{
+    public class When_creating_and_using_repositories_in_parallel
+    {
+        private readonly TestInMemoryEventStore _testStore;
+
+        private readonly ICache _cache;
+
+        private Exception _exception;
+
+        public When_creating_and_using_repositories_in_parallel()
+        {
+            _testStore = new TestInMemoryEventStore();
+            _cache = new CQRSlite.Caching.MemoryCache();
+
+            int numberOfAggregates = 10;
+            int numberOfIterations = 200;
+
+            Task[] tasks = Enumerable.Range(0, numberOfAggregates).Select(_ => Task.Run(async () =>
+            {
+                var aggregateId = Guid.NewGuid();
+                for (int iteration = 0; iteration < numberOfIterations; iteration++)
+                {
+                    var cacheRepository = new CacheRepository(new Repository(_testStore), _testStore, _cache);
+                    await cacheRepository.Save(new TestAggregate(aggregateId));
+                }
+            })).ToArray();
+
+            _exception = Record.Exception(() => Task.WaitAll(tasks));
+        }
+
+        [Fact]
+        public void Should_not_cause_concurrency_issues()
+        {
+            Assert.Null(_exception);
+        }
+    }
+}


### PR DESCRIPTION
Fixed concurrency errors in MemoryCache (gautema/CQRSlite#101)

When using dotnetcore, adding a cache entry lead to InvalidOperationExceptions 
if a new registration callback was added concurrently.

The issue was caused by re-using a single MemoryCacheEntryOptions for multiple 
cache entries. This change resolves the issue by creating a new options 
instance for each cache entry.

This causes a change of behavior with the eviction callbacks.
Previously, when using dotnetcore, all registered callbacks would be kept and 
invoked on a cache eviction.
Now, only the last registered callback will be invoked. This behavior is 
consistent with the implementation for .NET Framework 4.5.2.

The default implementation of CacheRepository will register a new callback in 
the constructor of each instance.
Because each callback modifies a static class field, it should not matter 
which callback is invoked.

It might, however, affect custom implementations.
