### PR TITLE
Update Microsoft.Extensions.Caching.Memory to 6.0.3

### DIFF
--- a/Framework/CQRSlite/CQRSlite.csproj
+++ b/Framework/CQRSlite/CQRSlite.csproj
@@ -39,7 +39,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0' ">
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.3" />
   </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' ">


### PR DESCRIPTION
This PR updates the vulnerable Microsoft.Extensions.Caching.Memory package from version 6.0.0 to 6.0.3 version in order to address a high-severity vulnerability.